### PR TITLE
Include metrics-server as a dependency for hpa enabled - CLM-26698

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: fluentd
   repository: https://charts.bitnami.com/bitnami
   version: 5.5.12
-digest: sha256:3001c4faf25aa8e74482a992d2e85b72bb0b4a6f0d9b6c6cce2c6f7f3874ac51
-generated: "2023-01-17T15:12:14.6881484Z"
+- name: metrics-server
+  repository: https://kubernetes-sigs.github.io/metrics-server
+  version: 3.10.0
+digest: sha256:b4c370c2d62c1f953aaab6cc5912e62b70538c38b940c0b4888721924d26d3cf
+generated: "2023-07-18T13:57:23.727119032+01:00"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -25,3 +25,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     version: 5.5.12
     condition: fluentd.enabled
+  - name: metrics-server
+    repository: https://kubernetes-sigs.github.io/metrics-server
+    version: 3.10.0
+    condition: hpa.enabled


### PR DESCRIPTION
**WHAT**
[metrics-server ](https://github.com/kubernetes-sigs/metrics-server/)is a requirement for enabling horizontal pod scaling (HPA). With https://github.com/sonatype/nexus-iq-server-ha/pull/15 we added support for HPA but requires a user to install metrics-server manually.

This adds metrics-server as a dependency with matching version and will be installed with the chart as long as the flag `hpa.enabled=true`  