### PR TITLE
CLM-26709 add resource constraints to fluentd sidecar

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -553,8 +553,10 @@ HPA is disabled by default. If you want to enable it, you need to set the `hpa.e
    ```
    --set hpa.enabled=true
    ```
-Defined resources limits for all the containers in the cluster are required for HPA to be able to properly compute
-metrics.
+Defined resources requests for all the containers in the IQ Server pod are required for HPA to be able to compute
+metrics. As a result, if you are scaling based on CPU usage you need to specify CPU requests for the IQ server and fluentd
+sidecar. 
+
 Please refer to the "Chart Configuration Options" table below for detailed parameters for adjusting HPA configuration
 to match your needs.
 
@@ -567,7 +569,9 @@ Some example commands are shown below.
     ...
     --set hpa.enabled=true
     --set iq_server.resources.requests.cpu="500m"
-    --set iq_server.resources.limits.cpu="1000m"
+    --set iq_server.resources.limits.cpu="1000m"    
+    --set fluentd.resources.requests.cpu="200m"
+    --set fluentd.resources.limits.cpu="500m"
     ...
    sonatype/nexus-iq-server-ha --version <version>
    ```
@@ -701,6 +705,10 @@ To upgrade Nexus IQ Server and ensure a successful data migration, the following
 | `aggregateLogFileRetention.deleteCron`                      | Cron schedule expression for when to delete old aggregate log files if needed                        | `0 1 * * *`                |
 | `aggregateLogFileRetention.maxLastModifiedDays`             | Maximum last modified time of an aggregate log file in days (0 disables deletion)                    | 50                         |
 | `fluentd.enabled`                                           | Enable Fluentd                                                                                       | `true`                     |
+| `fluentd.resources.requests.cpu`                            | Fluentd sidecar cpu request                                                                          | `nil`                      |
+| `fluentd.resources.limits.cpu`                              | Fluentd sidecar cpu limit                                                                            | `nil`                      |
+| `fluentd.resources.requests.memory`                         | Fluentd sidecar memory request                                                                       | `nil`                      |
+| `fluentd.resources.limits.memory`                           | Fluentd sidecar memory limit                                                                         | `nil`                      |
 | `fluentd.config`                                            | Fluentd configuration                                                                                | See `values.yaml`          |
 | `hpa.enabled`                                               | Enable Horizontal Pod Autoscaler                                                                     | `false`                    |
 | `hpa.minReplicas`                                           | Minimum number of replicas                                                                           | `2`                        |

--- a/chart/templates/iq-server-deployment.yaml
+++ b/chart/templates/iq-server-deployment.yaml
@@ -191,6 +191,21 @@ spec:
         - name: {{ .Release.Name }}-fluentd-container
           image: {{ .Values.fluentd.image.repository }}:{{ .Values.fluentd.image.tag }}
           imagePullPolicy: {{ .Values.fluentd.image.pullPolicy }}
+          resources:
+            requests:
+              {{- if .Values.fluentd.resources.requests.cpu }}
+              cpu: {{ .Values.fluentd.resources.requests.cpu }}
+              {{- end }}
+              {{- if .Values.fluentd.resources.requests.memory }}
+              memory: {{ .Values.fluentd.resources.requests.memory }}
+              {{- end }}
+            limits:
+              {{- if .Values.fluentd.resources.limits.cpu }}
+              cpu: {{ .Values.fluentd.resources.limits.cpu }}
+              {{- end }}
+              {{- if .Values.fluentd.resources.limits.memory }}
+              memory: {{ .Values.fluentd.resources.limits.memory }}
+              {{- end }}
           volumeMounts:
             - mountPath: "/opt/bitnami/fluentd/conf"
               name: {{ .Release.Name }}-fluentd-pod-config-volume

--- a/chart/tests/iq-server-deployment_test.yaml
+++ b/chart/tests/iq-server-deployment_test.yaml
@@ -118,6 +118,9 @@ tests:
                     image: bitnami/fluentd:1.15.3-debian-11-r20
                     imagePullPolicy: IfNotPresent
                     name: RELEASE-NAME-fluentd-container
+                    resources:
+                      requests:
+                      limits:
                     volumeMounts:
                       - mountPath: /opt/bitnami/fluentd/conf
                         name: RELEASE-NAME-fluentd-pod-config-volume
@@ -224,6 +227,14 @@ tests:
                 threshold: DEBUG
                 logFormat: "%d{'HH:mm:ss,SSSZ'} %level [%thread] %X{username} %logger - %msg%n"
           createSampleData: false
+      fluentd:
+        resources:
+          requests:
+            cpu: 2
+            memory: "500M"
+          limits:
+            cpu: 4
+            memory: "1Gi"
     asserts:
       - hasDocuments:
           count: 1
@@ -344,6 +355,13 @@ tests:
                     image: bitnami/fluentd:1.15.3-debian-11-r20
                     imagePullPolicy: IfNotPresent
                     name: RELEASE-NAME-fluentd-container
+                    resources:
+                      requests:
+                        cpu: 2
+                        memory: "500M"
+                      limits:
+                        cpu: 4
+                        memory: "1Gi"
                     volumeMounts:
                       - mountPath: /opt/bitnami/fluentd/conf
                         name: RELEASE-NAME-fluentd-pod-config-volume

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -308,6 +308,13 @@ aggregateLogFileRetention:
 # fluentd configuration
 fluentd:
   enabled: true
+  resources:
+    requests:
+      cpu: #150m
+      memory: #200M
+    limits:
+      cpu: #300m
+      memory: #400M
   config:
     # Configuration for sidecar forwarder
     # Note that source parsing formats must correspond to the Nexus IQ Server log formats


### PR DESCRIPTION
This change is to add support for resource request specification for the fluentd sidecar container that runs in the IQ pod. This is needed so that the HPA controller is able to properly calculate metrics in order for it scale a target which in this case is the IQ server deployment. 