### PR TITLE
Add annotations support to iq server pods - CLM-29017

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -659,6 +659,7 @@ To upgrade Sonatype IQ Server and ensure a successful data migration, the follow
 | `iq_server.persistence.csi.volumeHandle`                    | Volume handle                                                                                        | `nil`                      |
 | `iq_server.persistence.nfs.server`                          | NFS server hostname                                                                                  | `nil`                      |
 | `iq_server.persistence.nfs.path`                            | NFS server path                                                                                      | `/`                        |
+| `iq_server.podAnnotations`                                  | Annotations for the Sonatype IQ Server pods                                                          | `nil`                      |
 | `iq_server.serviceAccountName`                              | Sonatype IQ Server service account name                                                              | `default`                  |
 | `iq_server.serviceType`                                     | Sonatype IQ Server service type                                                                      | `ClusterIP`                |
 | `iq_server.applicationServiceAnnotations`                   | Annotations for the Sonatype IQ Server application service                                           | `nil`                      |

--- a/chart/templates/iq-server-deployment.yaml
+++ b/chart/templates/iq-server-deployment.yaml
@@ -11,6 +11,10 @@ spec:
     metadata:
       labels:
         name: {{ .Release.Name }}-iq-server
+    {{- with .Values.iq_server.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ .Values.iq_server.serviceAccountName }}
       volumes:

--- a/chart/tests/iq-server-deployment_test.yaml
+++ b/chart/tests/iq-server-deployment_test.yaml
@@ -176,6 +176,8 @@ tests:
           size: "2Gi"
           hostPath:
             path: "/mnt/iq"
+        podAnnotations:
+          key1: "value1"
         license: "/iq.lic"
         sshPrivateKey: "/private.key"
         sshKnownHosts: "/known_hosts"
@@ -254,6 +256,8 @@ tests:
               metadata:
                 labels:
                   name: RELEASE-NAME-iq-server
+                annotations:
+                  key1: value1
               spec:
                 serviceAccountName: "my-service-account"
                 containers:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -96,6 +96,8 @@ iq_server:
   applicationServiceAnnotations:
   # Annotations for the admin service
   adminServiceAnnotations:
+  # Annotations for the iq server pods
+  podAnnotations:
 
   # Number of pods to run
   replicas: 2


### PR DESCRIPTION
Allows adding annotations to iq server pods

via `values.yml`
```
iq_server:
  podAnnotations:
    key1: value1
    key2: value2
```

Or using params
```
helm install ...

--set iq_server.podAnnotations.key1="value1" \
--set iq_server.podAnnotations.key2="value2" \
```