### PR TITLE
Use multiline logger for clm-server log

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -382,8 +382,9 @@ fluentd:
           tag: iq_server.clm-server
           read_from_head: true
           parse:
-            $type: regexp
-            expression: /^((?<logtime>[^ ]* [^ ]*) (?<level>[^ ]*) \[(?<thread>[^\]]*)\] (?<username>[^ ]*) (?<logger>[^ ]*) - (?<message>.*))|(?<message>.*)$/
+            $type: multiline
+            format_firstline: /\d{4}-\d{1,2}-\d{1,2}/
+            format1: /^((?<logtime>[^ ]* [^ ]*) (?<level>[^ ]*) \[(?<thread>[^\]]*)\] (?<username>[^ ]*) (?<logger>[^ ]*) - (?<message>.*))|(?<message>.*)$/
             time_key: logtime
             time_format: "%Y-%m-%d %H:%M:%S,%L%z"
       # Get the stderr log


### PR DESCRIPTION
Story: CLM-28364

This wraps java stacktraces (multiline logs) in to a single message field value ( with line breaks and tabs replaced with `\n` and `\t` respectively) 

For example 
```
{
    "level": "ERROR",
    "thread": "main",
    "username": "*SYSTEM",
    "logger": "com.sonatype.insight.brain.service.InsightBrainService",
    "message": "Fatal error trying to start server\njava.lang.IllegalStateException: Fatal error trying to start server\n\tat com.sonatype.insight.brain.service.InsightBrainService$2.onError(InsightBrainService.java:215)\n\tat io.dropwizard.cli.Cli.run(Cli.java:82)\n\tat com.sonatype.insight.brain.service.InsightBrainService.run(InsightBrainService.java:230)\n\tat com.sonatype.insight.brain.service.InsightBrainService.main(InsightBrainService.java:136)\nCaused by: com.sonatype.insight.db.DatabaseException: java.sql.SQLException: Cannot create PoolableConnectionFactory (FATAL: password authentication failed for user \"nexusiqha\")\n\tat com.sonatype.insight.brain.db.DatabaseUtil.getDatabaseEngine(DatabaseUtil.java:203)\n\tat com.sonatype.insight.brain.db.DataSourceFactory.loadDataSource(DataSourceFactory.java:41)\n\tat com.sonatype.insight.db.AbstractDataSourceFactory.createNewDataSource(AbstractDataSourceFactory.java:65)\n\tat com.sonatype.insight.db.AbstractDataSourceFactory.createNewDataSource(AbstractDataSourceFactory.java:38)\n\tat com.sonatype.insight.brain.db.datastore.DefaultOperationalDataStore.init(DefaultOperationalDataStore.java:71)\n\tat com.sonatype.insight.brain.db.datastore.AbstractDataStore.initWithoutMigration(AbstractDataStore.java:42)\n\tat com.sonatype.insight.brain.utils.DatabaseProvisionUtils.initializeDatabasesWithoutMigration(DatabaseProvisionUtils.java:59)\n\tat com.sonatype.insight.brain.utils.DatabaseProvisionUtils.initializeDatabases(DatabaseProvisionUtils.java:49)\n\tat com.sonatype.insight.brain.service.InsightBrainService.run(InsightBrainService.java:265)\n\tat com.sonatype.insight.brain.service.InsightBrainService.run(InsightBrainService.java:95)\n\tat io.dropwizard.cli.EnvironmentCommand.run(EnvironmentCommand.java:67)\n\tat com.sonatype.insight.brain.service.InsightBrainService$2.run(InsightBrainService.java:209)\n\tat com.sonatype.insight.brain.service.InsightBrainService$2.run(InsightBrainService.java:187)\n\tat io.dropwizard.cli.ConfiguredCommand.run(ConfiguredCommand.java:98)\n\tat io.dropwizard.cli.Cli.run(Cli.java:78)\n\t... 2 common frames omitted\nCaused by: java.sql.SQLException: Cannot create PoolableConnectionFactory (FATAL: password authentication failed for user \"nexusiq\")\n\tat org.apache.commons.dbcp2.BasicDataSource.createPoolableConnectionFactory(BasicDataSource.java:633)\n\tat org.apache.commons.dbcp2.BasicDataSource.createDataSource(BasicDataSource.java:535)\n\tat org.apache.commons.dbcp2.BasicDataSource.getConnection(BasicDataSource.java:711)\n\tat com.sonatype.insight.brain.db.DatabaseUtil.getDatabaseEngine(DatabaseUtil.java:199)\n\t... 16 common frames omitted\nCaused by: org.postgresql.util.PSQLException: FATAL: password authentication failed for user \"nexusiq\"\n\tat org.postgresql.core.v3.ConnectionFactoryImpl.doAuthentication(ConnectionFactoryImpl.java:693)\n\tat org.postgresql.core.v3.ConnectionFactoryImpl.tryConnect(ConnectionFactoryImpl.java:203)\n\tat org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:258)\n\tat org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:54)\n\tat org.postgresql.jdbc.PgConnection.<init>(PgConnection.java:253)\n\tat org.postgresql.Driver.makeConnection(Driver.java:434)\n\tat org.postgresql.Driver.connect(Driver.java:291)\n\tat org.apache.commons.dbcp2.DriverConnectionFactory.createConnection(DriverConnectionFactory.java:52)\n\tat org.apache.commons.dbcp2.PoolableConnectionFactory.makeObject(PoolableConnectionFactory.java:414)\n\tat org.apache.commons.dbcp2.BasicDataSource.validateConnectionFactory(BasicDataSource.java:113)\n\tat org.apache.commons.dbcp2.BasicDataSource.createPoolableConnectionFactory(BasicDataSource.java:629)\n\t... 19 common frames omitted",
    "hostname": "cluster-iq-server-deployment-68f8467d78-zmq52",
    "fluentd_tag": "iq_server.clm-server",
    "time": "2024-01-16T10:31:41.648000000Z"
}


``` 