### PR TITLE
feat: allow for overriding of busybox image

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -725,3 +725,6 @@ To upgrade Sonatype IQ Server and ensure a successful data migration, the follow
 | `hpa.resource.cpu.average.threshold`                        | Average CPU threshold for autoscaling                                                                | `50`                       |
 | `hpa.resource.memory.enabled`                               | Enable memory-based autoscaling                                                                      | `false`                    |
 | `hpa.resource.memory.average.threshold`                     | Average memory threshold for autoscaling                                                             | `50`                       |
+| `busybox.imageRegistry`                                     | Container image registry, if not specified the Docker public registry will be used                   | `nil`                      |
+| `busybox.image`                                             | BusyBox docker image                                                                                 | `busybox`                  |
+| `busybox.tag`                                               | BusyBox image tag                                                                                    | See `values.yaml`          |

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -5,3 +5,7 @@
 {{- define "nexus-iq-server-ha.iqServerImage" -}}
 {{- if .Values.iq_server.imageRegistry }}{{ .Values.iq_server.imageRegistry }}/{{ .Values.iq_server.image }}:{{ .Values.iq_server.tag }}{{- else }}{{ .Values.iq_server.image }}:{{ .Values.iq_server.tag }}{{- end }}
 {{- end -}}
+
+{{- define "nexus-iq-server-ha.busyboxImage" -}}
+{{- if .Values.busybox.imageRegistry }}{{ .Values.busybox.imageRegistry }}/{{ .Values.busybox.image }}:{{ .Values.busybox.tag }}{{- else }}{{ .Values.busybox.image }}:{{ .Values.busybox.tag }}{{- end }}
+{{- end -}}

--- a/chart/templates/delete-old-aggregate-logs-cronjob.yaml
+++ b/chart/templates/delete-old-aggregate-logs-cronjob.yaml
@@ -18,7 +18,7 @@ spec:
                 claimName: {{- if .Values.iq_server.persistence.existingPersistentVolumeClaimName }} {{ .Values.iq_server.persistence.existingPersistentVolumeClaimName }}{{- else }} {{ .Values.iq_server.persistence.persistentVolumeClaimName }}{{- end }}
           containers:
           - name: "{{ .Release.Name }}-delete-old-aggregate-logs"
-            image: busybox:1.28
+            image: {{ include "nexus-iq-server-ha.busyboxImage" . }}
             imagePullPolicy: IfNotPresent
             command:
             - /bin/sh

--- a/chart/templates/iq-server-deployment.yaml
+++ b/chart/templates/iq-server-deployment.yaml
@@ -221,7 +221,7 @@ spec:
         {{- end }}
       initContainers:
         - name: {{ .Release.Name }}-set-iq-persistence-ownership
-          image: busybox:1.28
+          image: {{ include "nexus-iq-server-ha.busyboxImage" . }}
           command:
             - /bin/sh
             - -c

--- a/chart/tests/delete-old-aggregate-logs-cronjob_test.yaml
+++ b/chart/tests/delete-old-aggregate-logs-cronjob_test.yaml
@@ -58,6 +58,10 @@ tests:
       aggregateLogFileRetention:
         deleteCron: "0 2 * * *"
         maxLastModifiedDays: 1
+      busybox:
+        imageRegistry: registry.example.com
+        image: busybox2
+        tag: "1.29"
     asserts:
       - equal:
           path: spec.schedule
@@ -68,6 +72,9 @@ tests:
             - /bin/sh
             - -c
             - find /log/ -type f -mtime +0 -delete
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].image
+          value: registry.example.com/busybox2:1.29
   - it: is disabled if maxLastModifiedDays is 0
     set:
       aggregateLogFileRetention:

--- a/chart/tests/iq-server-deployment_test.yaml
+++ b/chart/tests/iq-server-deployment_test.yaml
@@ -230,6 +230,10 @@ tests:
                 logFormat: "%d{'HH:mm:ss,SSSZ'} %level [%thread] %X{username} %logger - %msg%n"
           createSampleData: false
         pvOwnershipOverride: "chown -R 2000:2000 /different/path"
+      busybox:
+        imageRegistry: registry.example.com
+        image: busybox2
+        tag: "1.29"
       fluentd:
         resources:
           requests:
@@ -377,7 +381,7 @@ tests:
                       - /bin/sh
                       - -c
                       - chown -R 2000:2000 /different/path
-                    image: busybox:1.28
+                    image: registry.example.com/busybox2:1.29
                     name: RELEASE-NAME-set-iq-persistence-ownership
                     volumeMounts:
                       - mountPath: /iq/clm-cluster

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -202,6 +202,11 @@ iq_server:
   # Specify a custom 'chown' command to modify ownership of directories.
   pvOwnershipOverride:  "chown -R 1000:1000 /sonatype-work/clm-cluster"
 
+busybox:
+  imageRegistry:
+  image: busybox
+  tag: 1.28
+
 # Horizontal pod auto-scaler 
 hpa:
   enabled: false 


### PR DESCRIPTION
Hi!

I'm trying to use this chart in an environment where we have a requirement to only use an internally hosted image registry.

I've added values overrides for the `busybox` image that's being pulled from Dockerhub by default to allow for that.