### PR TITLE
Add support for annotation DB Migration job

### DIFF
--- a/chart/templates/iq-server-jobs.yaml
+++ b/chart/templates/iq-server-jobs.yaml
@@ -2,6 +2,10 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ .Release.Name }}-migrate-db
+  {{- with .Values.iq_server.migrationJobAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   completions: 1
   parallelism: 1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -98,16 +98,18 @@ iq_server:
   adminServiceAnnotations:
   # Annotations for the iq server pods
   podAnnotations:
+  # Annoations to apply to the DB migration job
+  migrationJobAnnotations:
 
   # Number of pods to run
   replicas: 2
-  
+
   # One of these can be set to hold the initial admin password
   initialAdminPassword: "admin123" # Plaintext password
   # The name of an existing Kubernetes secret containing a password key with a value of the base64 encoding of your
   # password
   initialAdminPasswordSecret:
-  
+
   # Configures the readiness probe for each pod
   readinessProbe:
     initialDelaySeconds: 45
@@ -208,20 +210,20 @@ global:
     image: busybox
     tag: 1.28
 
-# Horizontal pod auto-scaler 
+# Horizontal pod auto-scaler
 hpa:
-  enabled: false 
+  enabled: false
   minReplicas: 2
   maxReplicas: 4
   resources:
-    cpu: 
+    cpu:
       enabled: true
-      average: 
+      average:
         threshold: 50
-    memory: 
+    memory:
       enabled: false
-      average: 
-          threshold: 60 
+      average:
+          threshold: 60
 
 # Load balancer
 ingress:


### PR DESCRIPTION
## Background
When using a GitOps tool like ArgoCD to manage the deployment of the nexus-iq-server-ha helm chart, the db-migration job will run in an infinite loop when automatic sync functionality is enabled. Most GitOps tools like ArgoCD allow for Sync Hooks to be applied via annotations on resources, which can control the lifecycle of resources.

Because the job template for the db-migration resource doesn't allow applying annotations, it's not possible to apply the necessary annotations to apply sync hooks.

## Proposed changes
- Update the db-migration job template to allow passing custom annotations to attach to the job resource.

## Testing
Run helm template command and validate output manifests match expected outcome with custom annotations applied to the job.