### PR TITLE
Add mountOptions for nfs persistent volume

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -659,6 +659,7 @@ To upgrade Sonatype IQ Server and ensure a successful data migration, the follow
 | `iq_server.persistence.csi.volumeHandle`                           | Volume handle                                                                                        | `nil`                      |
 | `iq_server.persistence.nfs.server`                                 | NFS server hostname                                                                                  | `nil`                      |
 | `iq_server.persistence.nfs.path`                                   | NFS server path                                                                                      | `/`                        |
+| `iq-server.persitence.nfs.mountOptions`                            | NFS server mount options                                                                                   | `nil`                      |
 | `iq_server.podAnnotations`                                         | Annotations for the Sonatype IQ Server pods                                                          | `nil`                      |
 | `iq_server.serviceAccountName`                                     | Sonatype IQ Server service account name                                                              | `default`                  |
 | `iq_server.serviceType`                                            | Sonatype IQ Server service type                                                                      | `ClusterIP`                |

--- a/chart/README.md
+++ b/chart/README.md
@@ -659,7 +659,7 @@ To upgrade Sonatype IQ Server and ensure a successful data migration, the follow
 | `iq_server.persistence.csi.volumeHandle`                           | Volume handle                                                                                        | `nil`                      |
 | `iq_server.persistence.nfs.server`                                 | NFS server hostname                                                                                  | `nil`                      |
 | `iq_server.persistence.nfs.path`                                   | NFS server path                                                                                      | `/`                        |
-| `iq-server.persitence.nfs.mountOptions`                            | NFS server mount options                                                                                   | `nil`                      |
+| `iq-server.persistence.nfs.mountOptions`                            | NFS server mount options                                                                                   | `nil`                      |
 | `iq_server.podAnnotations`                                         | Annotations for the Sonatype IQ Server pods                                                          | `nil`                      |
 | `iq_server.serviceAccountName`                                     | Sonatype IQ Server service account name                                                              | `default`                  |
 | `iq_server.serviceType`                                            | Sonatype IQ Server service type                                                                      | `ClusterIP`                |

--- a/chart/templates/iq-server-pv.yaml
+++ b/chart/templates/iq-server-pv.yaml
@@ -78,6 +78,12 @@ spec:
     readOnly: false
     server: {{ .Values.iq_server.persistence.nfs.server }}
     path: {{ .Values.iq_server.persistence.nfs.path }}
+  {{- if ((.Values.iq_server.persistence).nfs).mountOptions }}
+  {{- with .Values.iq_server.persistence.nfs.mountOptions }}
+  mountOptions:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
   {{- else if and ((.Values.iq_server.persistence).hostPath).path ((.Values.iq_server.persistence).hostPath).type }}
   hostPath:
     path: {{ .Values.iq_server.persistence.hostPath.path }}

--- a/chart/tests/iq-server-pv_test.yaml
+++ b/chart/tests/iq-server-pv_test.yaml
@@ -197,6 +197,9 @@ tests:
           nfs:
             server: "someServer"
             path: "somePath"
+            mountOptions:
+             - "someValue1"
+             - "someValue2"
     asserts:
       - equal:
           path: spec.nfs
@@ -204,6 +207,12 @@ tests:
             readOnly: false
             server: "someServer"
             path: "somePath"
+        documentIndex: 0
+      - equal:
+          path: spec.mountOptions
+          value:
+            - "someValue1"
+            - "someValue2"
         documentIndex: 0
 
   - it: can set hostPath

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -86,6 +86,7 @@ iq_server:
     nfs:
       server:
       path: "/"
+      mountOptions:
 
   # The service account to use to run the pods/job
   serviceAccountName: "default"


### PR DESCRIPTION
**Background:**
The Nexus IQ documentation recommends the following options for NFS, however the Helm chart does not allow setting these options in the nfs persistent volume.
`vers=4.2, noatime, nodiratime, rsize=1048576, wsize=1048576, timeo=600, retrans=2`
[source](https://help.sonatype.com/en/system-requirements.html)

**Proposal:**
Add optional mountOptions under `.Values.iq_server.persistence.nfs` to set these values.