### PR TITLE
Add helm hooks to DB migration job

### DIFF
--- a/chart/templates/iq-server-jobs.yaml
+++ b/chart/templates/iq-server-jobs.yaml
@@ -2,6 +2,9 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ .Release.Name }}-migrate-db
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
   completions: 1
   parallelism: 1

--- a/chart/tests/iq-server-jobs_test.yaml
+++ b/chart/tests/iq-server-jobs_test.yaml
@@ -21,6 +21,12 @@ tests:
           value: RELEASE-NAME-migrate-db
         documentIndex: 0
       - equal:
+          path: metadata.annotations
+          value:
+            "helm.sh/hook": pre-install,pre-upgrade
+            "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+        documentIndex: 0
+      - equal:
           path: spec
           value:
             completions: 1


### PR DESCRIPTION
When managing this helm release with ArgoCD, the migration job is recreated in an endless loop as syncs occur.  By adding Helm pre-install and pre-upgrade hooks and a hook deletion policy, the job will only be run when an actual installation or upgrade is run.

This resolves #31 