### PR TITLE
CLM-33049 Pass in optional iq-server-jobs annotations

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nexus-iq-server-ha
-version: 185.0.0
+version: 185.1.0
 appVersion: 1.185.0
 description: A cluster of Sonatype Nexus IQ Servers to continuously monitor your entire software supply chain
 type: application

--- a/chart/README.md
+++ b/chart/README.md
@@ -687,6 +687,12 @@ To upgrade Sonatype IQ Server and ensure a successful data migration, the follow
 | `iq_server.pvOwnershipOverrideResources.resources.requests.memory` | Persistence ownership initContainer request for memory resources in bytes                            | `nil`                      |
 | `iq_server.pvOwnershipOverrideResources.resources.limits.cpu`      | Persistence ownership initContainer limit for CPU resources in CPU units                             | `nil`                      |
 | `iq_server.pvOwnershipOverrideResources.resources.limits.memory`   | Persistence ownership initContainer limit for memory resources in bytes                              | `nil`                      |
+| `iq_server_jobs.migrationJobAnnotations`                           | Sonatype IQ DB Migration job Annotations                                                             | `nil`                      |
+| `iq_server_jobs.env`                                               | Sonatype IQ DB Migration job environment variables                                                   | `nil`                      |
+| `iq_server_jobs.resources.requests.cpu`                            | Sonatype IQ DB Migration job request for CPU resources in CPU units                                  | `nil`                      |
+| `iq_server_jobs.resources.requests.memory`                         | Sonatype IQ DB Migration job request for memory resources in bytes                                   | `nil`                      |
+| `iq_server_jobs.resources.limits.cpu`                              | Sonatype IQ DB Migration job limit for CPU resources in CPU units                                    | `nil`                      |
+| `iq_server_jobs.resources.limits.memory`                           | Sonatype IQ DB Migration job limit for memory resources in bytes                                     | `nil`                      |
 | `ingress.enabled`                                                  | Enable ingress                                                                                       | `false`                    |
 | `ingress.className`                                                | Ingress class name                                                                                   | `nginx`                    |
 | `ingress.pathType`                                                 | Ingress path type                                                                                    | `Prefix`                   |

--- a/chart/templates/iq-server-jobs.yaml
+++ b/chart/templates/iq-server-jobs.yaml
@@ -2,9 +2,10 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ .Release.Name }}-migrate-db
+  {{- with .Values.iq_server_jobs.migrationJobAnnotations }}
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   completions: 1
   parallelism: 1

--- a/chart/tests/iq-server-jobs_test.yaml
+++ b/chart/tests/iq-server-jobs_test.yaml
@@ -20,11 +20,8 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-migrate-db
         documentIndex: 0
-      - equal:
+      - isNull:
           path: metadata.annotations
-          value:
-            "helm.sh/hook": pre-install,pre-upgrade
-            "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
         documentIndex: 0
       - equal:
           path: spec
@@ -97,6 +94,9 @@ tests:
         imagePullPolicy: "Always"
         tag: "1.142.0-SNAPSHOT"
       iq_server_jobs:
+        migrationJobAnnotations:
+          "test_key_1": test_value_1
+          "test_key_2": test_value_2
         resources:
           requests:
             cpu: 2
@@ -126,6 +126,11 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-migrate-db
         documentIndex: 0
+      - equal:
+          path: metadata.annotations
+          value:
+            "test_key_1": test_value_1
+            "test_key_2": test_value_2
       - equal:
           path: spec
           value:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -223,6 +223,11 @@ iq_server:
       memory: #400M
 
 iq_server_jobs:
+  migrationJobAnnotations:
+    # Annotations to apply to the DB migration job
+    # "helm.sh/hook": pre-install,pre-upgrade
+    # "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+    # "helm.sh/hook-weight": "0"
   # We usually recommend not to specify default resources and to leave this as a conscious choice for the user.
   # This also increases the chance that the chart runs on environments with little resources.
   # The commented values below are the minimum recommended resources for production.


### PR DESCRIPTION
This fixes an issue with the iq-server-jobs annotation helm pre-install hook not allowing a fresh install of the Nexus IQ HA cluster chart, due to the not yet installed configuration map and secrets.

To re-enable the annotations these chart configuration options can be added:
```
iq_server_jobs:
  migrationJobAnnotations:
    "helm.sh/hook": pre-install,pre-upgrade
    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
    "helm.sh/hook-weight": "0"
```
