### PR TITLE
Make security context of main IQ server container configurable.

### DIFF
--- a/chart/templates/iq-server-deployment.yaml
+++ b/chart/templates/iq-server-deployment.yaml
@@ -17,6 +17,12 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ .Values.iq_server.serviceAccountName }}
+
+      {{- with .Values.iq_server.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
       volumes:
         - name: {{ .Release.Name }}-iq-server-pod-volume
           persistentVolumeClaim:

--- a/chart/tests/security-context_test.yaml
+++ b/chart/tests/security-context_test.yaml
@@ -1,0 +1,21 @@
+suite: security-context
+templates:
+  - iq-server-deployment.yaml
+tests:
+  - it: is disabled by default
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext
+          value: null
+  - it: Sets properties
+    set: 
+      iq_server:
+        securityContext: 
+          runAsUser: 1000
+          runAsGroup: 1000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            runAsUser: 1000
+            runAsGroup: 1000

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -215,6 +215,11 @@ iq_server:
       cpu: #300m
       memory: #400M
 
+  # Optional security context for the main pods.
+  securityContext: {}
+  #  runAsUser: 1000
+  #  runAsGroup: 1000
+
 iq_server_jobs:
   migrationJobAnnotations:
     # Annotations to apply to the DB migration job


### PR DESCRIPTION
It is sometimes necessary to provide a security context config for the main container. 

For example, when running in OpenShift, OpenShift by default runs containers under a random user id. This will cause file access in the IQ server to fail.  By setting a securityContext, OpenShift can be forced to run the container with a certain user or group, thus fixing file access. 