### PR TITLE
Remove expired link to ndjson

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -263,7 +263,7 @@ A fluentd sidecar container in the same pod tails these log files and forwards t
 aggregator.
 
 For each log file, the aggregator combines its content from each pod into an aggregated log file in
-[ndjson format](http://ndjson.org/), which is output with the current date to the shared file system PV by default to
+ndjson format, which is output with the current date to the shared file system PV by default to
 `/log` such that you end up with
 * `clm-server.<yyyyMMdd>.log`
 * `request.<yyyyMMdd>.log`


### PR DESCRIPTION
Change is here https://github.com/sonatype/nexus-iq-server-ha/tree/remove_expired_link/chart#logging-required

(search for ndjson)