### PR TITLE
Add startup probe for potentially long database migrations - CLM-35178

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -701,6 +701,10 @@ In this version all the fluentd sidecar options have been moved under the `fluen
 | `iq_server.replicas`                                               | Number of replicas                                                                                   | `2`                        |
 | `iq_server.initialAdminPassword`                                   | Initial admin password                                                                               | `admin123`                 |
 | `iq_server.initialAdminPasswordSecret`                             | Initial admin password secret                                                                        | `nil`                      |
+| `iq_server.startupProbe.initialDelaySeconds`                       | Initial delay seconds for startup probe                                                              | `30`                       |
+| `iq_server.startupProbe.periodSeconds`                             | Period seconds for startup probe                                                                     | `10`                       |
+| `iq_server.startupProbe.timeoutSeconds`                            | Timeout seconds for startup probe                                                                    | `2`                        |
+| `iq_server.startupProbe.failureThreshold`                          | Failure threshold for startup probe                                                                  | `180`                      |
 | `iq_server.readinessProbe.initialDelaySeconds`                     | Initial delay seconds for readiness probe                                                            | `45`                       |
 | `iq_server.readinessProbe.periodSeconds`                           | Period seconds for readiness probe                                                                   | `15`                       |
 | `iq_server.readinessProbe.timeoutSeconds`                          | Timeout seconds for readiness probe                                                                  | `5`                        |

--- a/chart/templates/iq-server-deployment.yaml
+++ b/chart/templates/iq-server-deployment.yaml
@@ -193,6 +193,21 @@ spec:
                 {{- end }}
               {{- end }}
             {{- end }}
+          startupProbe:
+            initialDelaySeconds: {{ .Values.iq_server.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.iq_server.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.iq_server.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.iq_server.startupProbe.failureThreshold }}
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  {{- if .Values.iq_server.config.server.adminConnectors }}
+                    {{- with index .Values.iq_server.config.server.adminConnectors 0 }}
+                      curl -If {{ .type }}://localhost:{{ .port }}/{{- if include "nexus-iq-server-ha.trimSpaceAndForwardSlashes" $.Values.iq_server.config.server.adminContextPath }}{{ include "nexus-iq-server-ha.trimSpaceAndForwardSlashes" $.Values.iq_server.config.server.adminContextPath }}/{{- end }}ping
+                    {{- end }}
+                  {{- end }}
           readinessProbe:
             initialDelaySeconds: {{ .Values.iq_server.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.iq_server.readinessProbe.periodSeconds }}

--- a/chart/tests/iq-server-config-map_test.yaml
+++ b/chart/tests/iq-server-config-map_test.yaml
@@ -111,6 +111,11 @@ tests:
         license: "/iq.lic"
         replicas: 1
         initialAdminPassword: "admin!234"
+        startupProbe:
+          initialDelaySeconds: 60
+          periodSeconds: 20
+          timeoutSeconds: 4
+          failureThreshold: 360
         readinessProbe:
           initialDelaySeconds: 60
           periodSeconds: 30

--- a/chart/tests/iq-server-deployment_test.yaml
+++ b/chart/tests/iq-server-deployment_test.yaml
@@ -86,6 +86,17 @@ tests:
                         name: application-0
                       - containerPort: 8071
                         name: admin-0
+                    startupProbe:
+                      exec:
+                        command:
+                          - /bin/sh
+                          - -c
+                          - |
+                            curl -If http://localhost:8071/ping
+                      failureThreshold: 180
+                      initialDelaySeconds: 30
+                      periodSeconds: 10
+                      timeoutSeconds: 2
                     readinessProbe:
                       exec:
                         command:
@@ -198,6 +209,11 @@ tests:
         sshKnownHosts: "/known_hosts"
         replicas: 1
         initialAdminPassword: "admin!234"
+        startupProbe:
+          initialDelaySeconds: 60
+          periodSeconds: 20
+          timeoutSeconds: 4
+          failureThreshold: 360
         readinessProbe:
           initialDelaySeconds: 60
           periodSeconds: 30
@@ -364,6 +380,17 @@ tests:
                         name: application-0
                       - containerPort: 8073
                         name: admin-0
+                    startupProbe:
+                      exec:
+                        command:
+                          - /bin/sh
+                          - -c
+                          - |
+                            curl -If https://localhost:8073/admin/ping
+                      failureThreshold: 360
+                      initialDelaySeconds: 60
+                      periodSeconds: 20
+                      timeoutSeconds: 4
                     readinessProbe:
                       exec:
                         command:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -120,6 +120,12 @@ iq_server:
   # password
   initialAdminPasswordSecret:
   
+  # Configures the startup probe for each pod
+  startupProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 180
   # Configures the readiness probe for each pod
   readinessProbe:
     initialDelaySeconds: 45


### PR DESCRIPTION
JIRA: https://sonatype.atlassian.net/browse/CLM-35178
Similar to: https://github.com/sonatype/helm3-charts/pull/282