### PR TITLE
Update from abandoned unittest plugin & soon-to-be EOL helm 3

### DIFF
--- a/.github/workflows/helm-tests.yaml
+++ b/.github/workflows/helm-tests.yaml
@@ -11,12 +11,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4
         with:
-          version: v3.14.4
+          version: v4.1.3
 
       - name: Install dependencies
         run: helm dependency update chart/
@@ -28,7 +28,8 @@ jobs:
         run: helm template chart/
 
       - name: Install unittest plugin
-        run: helm plugin install https://github.com/quintush/helm-unittest --version v0.2.11
+        # --verify=false: plugin does not yet ship .prov files (https://github.com/helm-unittest/helm-unittest/issues/777)
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --verify=false
 
       - name: Run Helm tests
-        run: helm unittest --helm3 chart/
+        run: helm unittest chart/

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ helm lint chart
 The existing unit tests are intended to be run using the `helm-unittest` plugin, which can be installed as follows
 
 ```
-# If using Helm v4+, append --verify=false (https://github.com/helm-unittest/helm-unittest/issues/777)
-helm plugin install https://github.com/quintush/helm-unittest --version v0.2.11
+# --verify=false: plugin does not yet ship .prov files (https://github.com/helm-unittest/helm-unittest/issues/777)
+helm plugin install https://github.com/helm-unittest/helm-unittest.git --verify=false
 ```
 
 The test suites are located in the [chart/tests directory](./chart/tests). Each test file name must end in
 `_test.yaml` in order for the plugin to automatically execute it.
 
-To run all unit tests, execute `helm unittest --helm3 chart`.
+To run all unit tests, execute `helm unittest chart`.
 
-To run an individual unit test, execute `helm unittest --helm3 chart --file chart/tests/<name_test.yaml>`.
+To run an individual unit test, execute `helm unittest chart --file chart/tests/<name_test.yaml>`.

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,8 @@
 # Eclipse Foundation. All other trademarks are the property of their respective owners.
 #
 
-helm plugin install https://github.com/quintush/helm-unittest --version v0.2.11
+# --verify=false: plugin does not yet ship .prov files (https://github.com/helm-unittest/helm-unittest/issues/777)
+helm plugin install https://github.com/helm-unittest/helm-unittest.git --verify=false
 
 set -e
 
@@ -23,7 +24,7 @@ helm dependency update chart
 helm lint chart
 
 # unit test
-(cd ./chart; helm unittest -3 -t junit -o test-output.xml .)
+(cd ./chart; helm unittest -t junit -o test-output.xml .)
 
 # package the chart into tgz archives
 helm package chart --destination docs

--- a/chart/README.md
+++ b/chart/README.md
@@ -20,7 +20,7 @@ This repository is intended to store a helm chart to create a cluster of Sonatyp
 - A copy of the helm chart
 - A Sonatype IQ Server license that supports the High Availability (HA) feature
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) (1.23+) to run commands against a Kubernetes cluster
-- [helm](https://helm.sh/docs/helm/) (3.9.3+) to install or upgrade the helm chart
+- [helm](https://helm.sh/docs/helm/) (3.9.3+ or 4.x) to install or upgrade the helm chart
 - A PostgreSQL (10.7 or newer) database or a PostgreSQL-compatible service
 - A Kubernetes cluster to run the helm chart on
 - A shared file system to share files between all Sonatype IQ Server pods in the cluster

--- a/chart/tests/horizontal-pod-autoscaler_test.yaml
+++ b/chart/tests/horizontal-pod-autoscaler_test.yaml
@@ -55,9 +55,8 @@ tests:
       - equal:
           path: spec.metrics[0].resource.target.averageUtilization
           value: 50          
-      - equal:
+      - notExists:
           path: spec.metrics[1]
-          value: null
   - it: renders with defaults when hpa and hpa memory resource is enabled
     set:
       hpa: 

--- a/chart/tests/ingress_test.yaml
+++ b/chart/tests/ingress_test.yaml
@@ -50,23 +50,20 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-ingress
         documentIndex: 1
-      - equal:
+      - notExists:
           path: metadata.annotations
-          value: null
         documentIndex: 1
       - equal:
           path: spec.ingressClassName
           value: nginx
         documentIndex: 1
       # tls
-      - equal:
+      - notExists:
           path: spec.tls
-          value: null
         documentIndex: 1
       # host 1
-      - equal:
+      - notExists:
           path: spec.rules[0].host
-          value: null
         documentIndex: 1
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.name
@@ -85,9 +82,8 @@ tests:
           value: Prefix
         documentIndex: 1
       # host 2
-      - equal:
+      - notExists:
           path: spec.rules[1].host
-          value: null
         documentIndex: 1
       - equal:
           path: spec.rules[1].http.paths[0].backend.service.name
@@ -192,9 +188,8 @@ tests:
           value: ingress-tls-secret
         documentIndex: 2
       # host 1
-      - equal:
+      - notExists:
           path: spec.rules[0].host
-          value: null
         documentIndex: 2
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.name
@@ -213,9 +208,8 @@ tests:
           value: Prefix
         documentIndex: 2
       # host 2
-      - equal:
+      - notExists:
           path: spec.rules[1].host
-          value: null
         documentIndex: 2
       - equal:
           path: spec.rules[1].http.paths[0].backend.service.name

--- a/chart/tests/security-context_test.yaml
+++ b/chart/tests/security-context_test.yaml
@@ -4,9 +4,8 @@ templates:
 tests:
   - it: is disabled by default
     asserts:
-      - equal:
+      - notExists:
           path: spec.template.spec.securityContext
-          value: null
   - it: Sets properties
     set: 
       iq_server:


### PR DESCRIPTION
quintush/helm-unittest is archived & unsupported, and the readme instructions don't work with current helm.
This updates both, so that it should work out-of-the-box for new users like me 🙂

See:
* https://helm.sh/community/hips/hip-0012/#maintaining-helm-3:~:text=Helm%203%20will%20reach%20end%20of%20life%206%2D8%20months%20after%20Helm%204%20release%20(July%202026%20estimated)
  * > Helm 3 will reach end of life 6-8 months after Helm 4 release (July 2026 estimated)
* https://github.com/quintush/helm-unittest
  * > This repository was archived by the owner on Aug 16, 2025. It is now read-only.