### PR TITLE
CLM-39991: create log directory before touch in init container

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nexus-iq-server-ha
-version: 204.0.0
+version: 204.0.1
 appVersion: 1.204.0
 description: A cluster of Sonatype Nexus IQ Servers to continuously monitor your entire software supply chain
 type: application

--- a/chart/templates/iq-server-deployment.yaml
+++ b/chart/templates/iq-server-deployment.yaml
@@ -280,7 +280,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - touch {{ .Values.iq_server.config.clusterDirectory }}/log/$(HOSTNAME)-stderr.log && {{ .Values.iq_server.pvOwnershipOverride }}
+            - mkdir -p {{ .Values.iq_server.config.clusterDirectory }}/log && touch {{ .Values.iq_server.config.clusterDirectory }}/log/$(HOSTNAME)-stderr.log && {{ .Values.iq_server.pvOwnershipOverride }}
           env:
             - name: HOSTNAME
               valueFrom:

--- a/chart/tests/iq-server-deployment_test.yaml
+++ b/chart/tests/iq-server-deployment_test.yaml
@@ -132,8 +132,8 @@ tests:
                   - command:
                       - /bin/sh
                       - -c
-                      - touch /sonatype-work/clm-cluster/log/$(HOSTNAME)-stderr.log &&
-                        chown -R 1000:1000 /sonatype-work/clm-cluster
+                      - mkdir -p /sonatype-work/clm-cluster/log && touch /sonatype-work/clm-cluster/log/$(HOSTNAME)-stderr.log
+                        && chown -R 1000:1000 /sonatype-work/clm-cluster
                     env:
                       - name: HOSTNAME
                         valueFrom:
@@ -401,7 +401,8 @@ tests:
                   - command:
                       - /bin/sh
                       - -c
-                      - touch /iq/clm-cluster/log/$(HOSTNAME)-stderr.log && chown -R 2000:2000 /different/path
+                      - mkdir -p /iq/clm-cluster/log && touch /iq/clm-cluster/log/$(HOSTNAME)-stderr.log
+                        && chown -R 2000:2000 /different/path
                     env:
                       - name: HOSTNAME
                         valueFrom:


### PR DESCRIPTION
Jira: https://sonatype.atlassian.net/browse/CLM-39991

## Summary
- The init container `nexus-iq-set-iq-persistence-ownership` runs `touch` on a stderr log file under the persistent volume but does not first create the parent directory. On a fresh PV (e.g. a newly-provisioned EFS volume) the directory does not exist and the init container fails with `No such file or directory`, leaving the pod stuck in `Init:CrashLoopBackOff`.
- Fix: add `mkdir -p {{ .Values.iq_server.config.clusterDirectory }}/log` before the `touch`. The existing `chown -R` then applies to the new directory. `mkdir -p` is idempotent so existing PVs (where the directory is already present) are unaffected.
- Bumps chart version `204.0.0` → `204.0.1` (patch).

This is a regression introduced by CLM-39118 (removed bundled Fluentd, redirected log appenders to the persistent path). Customer impact: HDI Ag (Zendesk #121193) — pods fail to start after upgrade on freshly-provisioned EFS volumes.

A longer-term replacement of the init container with `securityContext.fsGroup` is tracked separately under [CLM-39357](https://sonatype.atlassian.net/browse/CLM-39357); this PR is the targeted hotfix.

## Reproduction (local kind cluster, hostPath PV with empty dir)

**Before fix** — init container crashloops with the exact ticket error:
```
$ kubectl get pods -n iq-test
NAME                                         READY   STATUS                  RESTARTS
my-iq-iq-server-deployment-fc6b48c7b-dxcw8   0/1     Init:CrashLoopBackOff   1

$ kubectl logs -n iq-test <pod> -c my-iq-set-iq-persistence-ownership
touch: /sonatype-work/clm-cluster/log/my-iq-iq-server-deployment-fc6b48c7b-dxcw8-stderr.log: No such file or directory
```

**After fix** — init container exits 0, log directory and stderr file are created with correct ownership:
```
$ kubectl get pod -n iq-test <pod> -o jsonpath='{.status.initContainerStatuses[*].state}'
{"terminated":{"exitCode":0,"reason":"Completed",...}}

$ kubectl logs -n iq-test <pod> -c my-iq-set-iq-persistence-ownership
(empty)

$ ls -la /tmp/iq-pv/log/
drwxr-xr-x 2 1000 1000   120 Jun  9 07:09 .
-rw-r--r-- 1 1000 1000     0 my-iq-iq-server-deployment-...-stderr.log
```

The pod still `CrashLoopBackOff`s in the *main* container after init due to a missing DB / license in the minimal test setup — that's expected and unrelated to CLM-39991.

## Test plan
- [x] `helm lint chart` passes
- [x] `helm template` shows `mkdir -p ... && touch ... && chown -R ...` in the rendered init container command
- [x] Reproduce failure on unfixed `main` against an empty-dir hostPath PV (init container crashloops with ticket error)
- [x] Verify fix: same setup, init container exits 0, `/log` directory created with `1000:1000` ownership
- [ ] CI green
- [ ] Reviewer to confirm chart-testing / snapshot tests (if any) are updated as needed

[CLM-39357]: https://sonatype.atlassian.net/browse/CLM-39357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ