### PR TITLE
CLM-39125 - Fix for helm versions below 3.13, which is what our Jenkins build is using

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,8 +12,15 @@
 # Eclipse Foundation. All other trademarks are the property of their respective owners.
 #
 
-# --verify=false: plugin does not yet ship .prov files (https://github.com/helm-unittest/helm-unittest/issues/777)
-helm plugin install https://github.com/helm-unittest/helm-unittest.git --verify=false
+# plugin does not yet ship .prov files (https://github.com/helm-unittest/helm-unittest/issues/777)
+# --verify=false is only supported in Helm 3.13+, so check version first
+HELM_MAJOR=$(helm version --template '{{ .Version }}' | sed 's/v//' | cut -d. -f1)
+HELM_MINOR=$(helm version --template '{{ .Version }}' | cut -d. -f2)
+if [ "$HELM_MAJOR" -ge 4 ] || { [ "$HELM_MAJOR" -eq 3 ] && [ "$HELM_MINOR" -ge 13 ]; }; then
+  helm plugin install https://github.com/helm-unittest/helm-unittest.git --verify=false
+else
+  helm plugin install https://github.com/helm-unittest/helm-unittest.git
+fi
 
 set -e
 


### PR DESCRIPTION
https://sonatype.atlassian.net/browse/CLM-39125

The Jenkins build failed since it uses helm 3.10, which doesn’t support the `--verify` flag that was added in the previous PR. This fix is to accommodate older helm versions, so we only use the `--verify` flag for helm versions 3.13 and greater.

Currently `main` is broken due to the failed jenkins build: https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/HA/job/Main%20Snapshot%20Build/1363/console