### PR TITLE
CLM-39125 - Follow up fix to upgrade docker helm and clean install plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # Eclipse Foundation. All other trademarks are the property of their respective owners.
 #
 
-FROM sonatype.repo.sonatype.app/docker-all/alpine/helm:3.10.2
+FROM sonatype.repo.sonatype.app/docker-all/alpine/helm:4.2.0
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh

--- a/build.sh
+++ b/build.sh
@@ -14,12 +14,19 @@
 
 # plugin does not yet ship .prov files (https://github.com/helm-unittest/helm-unittest/issues/777)
 # --verify=false is only supported in Helm 3.13+, so check version first
+# Remove any existing incompatible plugin version before installing
+helm plugin uninstall unittest 2>/dev/null || true
+
+# Install helm-unittest plugin
+# Note: The plugin's platformHooks field requires Helm 3.13+, so use an older
+# plugin version for older Helm versions.
 HELM_MAJOR=$(helm version --template '{{ .Version }}' | sed 's/v//' | cut -d. -f1)
 HELM_MINOR=$(helm version --template '{{ .Version }}' | cut -d. -f2)
 if [ "$HELM_MAJOR" -ge 4 ] || { [ "$HELM_MAJOR" -eq 3 ] && [ "$HELM_MINOR" -ge 13 ]; }; then
   helm plugin install https://github.com/helm-unittest/helm-unittest.git --verify=false
 else
-  helm plugin install https://github.com/helm-unittest/helm-unittest.git
+  # v0.7.2 is the last version without platformHooks (which requires Helm 3.13+)
+  helm plugin install https://github.com/helm-unittest/helm-unittest.git --version v0.7.2
 fi
 
 set -e


### PR DESCRIPTION
https://sonatype.atlassian.net/browse/CLM-39125

Another follow up fix to upgrade helm version and do a clean install of the unittest plugin since last main build failed because the existing plugin was incompatible with helm version: https://jenkins.ci.sonatype.dev/job/insight/job/insight-brain/job/HA/job/Main%20Snapshot%20Build/1364/console

Summary of the fix:

1. Remove any existing plugin first - helm plugin uninstall unittest prevents the cached incompatible plugin from causing issues
2. Use version-appropriate plugin:
 - Helm 4.x or 3.13+ → Install latest helm-unittest with --verify=false
 - Older Helm (< 3.13) → Install v0.7.2 which doesn't have platformHooks

The platformHooks field was introduced in helm-unittest v1.1.0 and requires Helm 3.13+. Version v0.7.2 is the last stable release without this field.
