### PR TITLE
Remove broken commented-out Helm hook examples from migrationJobAnnotations - CLM-36127

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -294,9 +294,6 @@ iq_server:
 iq_server_jobs:
   migrationJobAnnotations:
     # Annotations to apply to the DB migration job
-    # "helm.sh/hook": pre-install,pre-upgrade
-    # "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
-    # "helm.sh/hook-weight": "0"
   # We usually recommend not to specify default resources and to leave this as a conscious choice for the user.
   # This also increases the chance that the chart runs on environments with little resources.
   # The commented values below are the minimum recommended resources for production.


### PR DESCRIPTION
Jira: https://sonatype.atlassian.net/browse/CLM-36127

The commented-out `helm.sh/hook` examples don't work: the migrate-db job mounts a regular ConfigMap that doesn't exist during the hook phase, so the pod fails with `FailedMount` and stays in `ContainerCreating`. The misleading examples are removed; the `migrationJobAnnotations` field stays configurable.