### PR TITLE
Make migrate-db job spec configurable to fix GitOps job loop - CLM-30003

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -901,8 +901,9 @@ This ensures that support can access aggregated logs from all HA nodes.
 | `iq_server.tolerations`                                            | Tolerations for pod assignment                                                                       | `[]`                       |
 | `iq_server.affinity`                                               | Affinity rules for pod assignment                                                                    | `{}`                       |
 | `iq_server_jobs.migrationJobAnnotations`                           | Sonatype IQ DB Migration job Annotations                                                             | `nil`                      |
+| `iq_server_jobs.migrationJobSpec`                                 | Top-level spec fields merged into the migrate-db job; set a key to `null` to omit it                 | `{ttlSecondsAfterFinished: 0}` |
 | `iq_server_jobs.gitSshJobAnnotations`                             | git-ssh job Annotations (rendered only when `iq_server.useGitSsh` is true)                           | `nil`                      |
-| `iq_server_jobs.jobSpec`                                           | Top-level spec fields merged into the migrate-db and git-ssh jobs; set a key to `null` to omit it    | `{ttlSecondsAfterFinished: 0}` |
+| `iq_server_jobs.gitSshJobSpec`                                    | Top-level spec fields merged into the git-ssh job; set a key to `null` to omit it                    | `{ttlSecondsAfterFinished: 0}` |
 | `iq_server_jobs.env`                                               | Sonatype IQ DB Migration job environment variables                                                   | `nil`                      |
 | `iq_server_jobs.resources.requests.cpu`                            | Sonatype IQ DB Migration job request for CPU resources in CPU units                                  | `nil`                      |
 | `iq_server_jobs.resources.requests.memory`                         | Sonatype IQ DB Migration job request for memory resources in bytes                                   | `nil`                      |

--- a/chart/README.md
+++ b/chart/README.md
@@ -901,6 +901,7 @@ This ensures that support can access aggregated logs from all HA nodes.
 | `iq_server.tolerations`                                            | Tolerations for pod assignment                                                                       | `[]`                       |
 | `iq_server.affinity`                                               | Affinity rules for pod assignment                                                                    | `{}`                       |
 | `iq_server_jobs.migrationJobAnnotations`                           | Sonatype IQ DB Migration job Annotations                                                             | `nil`                      |
+| `iq_server_jobs.jobSpec`                                           | Top-level spec fields merged into the migrate-db and git-ssh jobs; set a key to `null` to omit it    | `{ttlSecondsAfterFinished: 0}` |
 | `iq_server_jobs.env`                                               | Sonatype IQ DB Migration job environment variables                                                   | `nil`                      |
 | `iq_server_jobs.resources.requests.cpu`                            | Sonatype IQ DB Migration job request for CPU resources in CPU units                                  | `nil`                      |
 | `iq_server_jobs.resources.requests.memory`                         | Sonatype IQ DB Migration job request for memory resources in bytes                                   | `nil`                      |

--- a/chart/README.md
+++ b/chart/README.md
@@ -901,6 +901,7 @@ This ensures that support can access aggregated logs from all HA nodes.
 | `iq_server.tolerations`                                            | Tolerations for pod assignment                                                                       | `[]`                       |
 | `iq_server.affinity`                                               | Affinity rules for pod assignment                                                                    | `{}`                       |
 | `iq_server_jobs.migrationJobAnnotations`                           | Sonatype IQ DB Migration job Annotations                                                             | `nil`                      |
+| `iq_server_jobs.gitSshJobAnnotations`                             | git-ssh job Annotations (rendered only when `iq_server.useGitSsh` is true)                           | `nil`                      |
 | `iq_server_jobs.jobSpec`                                           | Top-level spec fields merged into the migrate-db and git-ssh jobs; set a key to `null` to omit it    | `{ttlSecondsAfterFinished: 0}` |
 | `iq_server_jobs.env`                                               | Sonatype IQ DB Migration job environment variables                                                   | `nil`                      |
 | `iq_server_jobs.resources.requests.cpu`                            | Sonatype IQ DB Migration job request for CPU resources in CPU units                                  | `nil`                      |

--- a/chart/templates/iq-server-jobs.yaml
+++ b/chart/templates/iq-server-jobs.yaml
@@ -131,7 +131,15 @@ metadata:
 spec:
   completions: 1
   parallelism: 1
-  ttlSecondsAfterFinished: 0
+  {{- $gitSshSpec := dict }}
+  {{- range $k, $v := .Values.iq_server_jobs.jobSpec }}
+  {{- if not (kindIs "invalid" $v) }}
+  {{- $_ := set $gitSshSpec $k $v }}
+  {{- end }}
+  {{- end }}
+  {{- if $gitSshSpec }}
+  {{- toYaml $gitSshSpec | nindent 2 }}
+  {{- end }}
   template:
     spec:
       serviceAccountName: {{ .Values.iq_server.serviceAccountName }}

--- a/chart/templates/iq-server-jobs.yaml
+++ b/chart/templates/iq-server-jobs.yaml
@@ -9,14 +9,14 @@ metadata:
 spec:
   completions: 1
   parallelism: 1
-  {{- $clean := dict }}
-  {{- range $k, $v := .Values.iq_server_jobs.jobSpec }}
+  {{- $migrationSpec := dict }}
+  {{- range $k, $v := .Values.iq_server_jobs.migrationJobSpec }}
   {{- if not (kindIs "invalid" $v) }}
-  {{- $_ := set $clean $k $v }}
+  {{- $_ := set $migrationSpec $k $v }}
   {{- end }}
   {{- end }}
-  {{- if $clean }}
-  {{- toYaml $clean | nindent 2 }}
+  {{- if $migrationSpec }}
+  {{- toYaml $migrationSpec | nindent 2 }}
   {{- end }}
   template:
     spec:
@@ -136,7 +136,7 @@ spec:
   completions: 1
   parallelism: 1
   {{- $gitSshSpec := dict }}
-  {{- range $k, $v := .Values.iq_server_jobs.jobSpec }}
+  {{- range $k, $v := .Values.iq_server_jobs.gitSshJobSpec }}
   {{- if not (kindIs "invalid" $v) }}
   {{- $_ := set $gitSshSpec $k $v }}
   {{- end }}

--- a/chart/templates/iq-server-jobs.yaml
+++ b/chart/templates/iq-server-jobs.yaml
@@ -9,7 +9,11 @@ metadata:
 spec:
   completions: 1
   parallelism: 1
-  ttlSecondsAfterFinished: 0
+  {{- range $k, $v := .Values.iq_server_jobs.jobSpec }}
+  {{- if not (kindIs "invalid" $v) }}
+  {{ $k }}: {{ $v }}
+  {{- end }}
+  {{- end }}
   template:
     spec:
       serviceAccountName: {{ .Values.iq_server.serviceAccountName }}

--- a/chart/templates/iq-server-jobs.yaml
+++ b/chart/templates/iq-server-jobs.yaml
@@ -9,10 +9,14 @@ metadata:
 spec:
   completions: 1
   parallelism: 1
+  {{- $clean := dict }}
   {{- range $k, $v := .Values.iq_server_jobs.jobSpec }}
   {{- if not (kindIs "invalid" $v) }}
-  {{ $k }}: {{ $v }}
+  {{- $_ := set $clean $k $v }}
   {{- end }}
+  {{- end }}
+  {{- if $clean }}
+  {{- toYaml $clean | nindent 2 }}
   {{- end }}
   template:
     spec:

--- a/chart/templates/iq-server-jobs.yaml
+++ b/chart/templates/iq-server-jobs.yaml
@@ -128,6 +128,10 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ .Release.Name }}-git-ssh
+  {{- with .Values.iq_server_jobs.gitSshJobAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   completions: 1
   parallelism: 1

--- a/chart/tests/iq-server-jobs_test.yaml
+++ b/chart/tests/iq-server-jobs_test.yaml
@@ -592,3 +592,17 @@ tests:
           path: spec.backoffLimit
           value: 3
         documentIndex: 1
+  - it: renders gitSshJobAnnotations onto the git-ssh job
+    set:
+      iq_server:
+        tag: "1.148.0"
+        useGitSsh: true
+      iq_server_jobs:
+        gitSshJobAnnotations:
+          argocd.argoproj.io/sync-options: Replace=true
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            argocd.argoproj.io/sync-options: Replace=true
+        documentIndex: 1

--- a/chart/tests/iq-server-jobs_test.yaml
+++ b/chart/tests/iq-server-jobs_test.yaml
@@ -562,3 +562,33 @@ tests:
           path: spec.podFailurePolicy.rules[0].onExitCodes.values[0]
           value: 1
         documentIndex: 0
+  - it: omits ttlSecondsAfterFinished on the git-ssh job when jobSpec value is null
+    set:
+      iq_server:
+        tag: "1.148.0"
+        useGitSsh: true
+      iq_server_jobs:
+        jobSpec:
+          ttlSecondsAfterFinished: null
+    asserts:
+      - isNull:
+          path: spec.ttlSecondsAfterFinished
+        documentIndex: 1
+  - it: renders extra jobSpec fields onto the git-ssh job
+    set:
+      iq_server:
+        tag: "1.148.0"
+        useGitSsh: true
+      iq_server_jobs:
+        jobSpec:
+          ttlSecondsAfterFinished: 120
+          backoffLimit: 3
+    asserts:
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 120
+        documentIndex: 1
+      - equal:
+          path: spec.backoffLimit
+          value: 3
+        documentIndex: 1

--- a/chart/tests/iq-server-jobs_test.yaml
+++ b/chart/tests/iq-server-jobs_test.yaml
@@ -513,23 +513,23 @@ tests:
                         values:
                           - iq-pool
         documentIndex: 0
-  - it: omits ttlSecondsAfterFinished when jobSpec value is null
+  - it: omits ttlSecondsAfterFinished when migrationJobSpec value is null
     set:
       iq_server:
         tag: "1.148.0"
       iq_server_jobs:
-        jobSpec:
+        migrationJobSpec:
           ttlSecondsAfterFinished: null
     asserts:
       - isNull:
           path: spec.ttlSecondsAfterFinished
         documentIndex: 0
-  - it: renders extra jobSpec fields onto the migrate-db job
+  - it: renders extra migrationJobSpec fields onto the migrate-db job
     set:
       iq_server:
         tag: "1.148.0"
       iq_server_jobs:
-        jobSpec:
+        migrationJobSpec:
           ttlSecondsAfterFinished: 120
           backoffLimit: 3
     asserts:
@@ -541,12 +541,12 @@ tests:
           path: spec.backoffLimit
           value: 3
         documentIndex: 0
-  - it: renders structured jobSpec fields onto the migrate-db job
+  - it: renders structured migrationJobSpec fields onto the migrate-db job
     set:
       iq_server:
         tag: "1.148.0"
       iq_server_jobs:
-        jobSpec:
+        migrationJobSpec:
           podFailurePolicy:
             rules:
               - action: FailJob
@@ -562,25 +562,38 @@ tests:
           path: spec.podFailurePolicy.rules[0].onExitCodes.values[0]
           value: 1
         documentIndex: 0
-  - it: omits ttlSecondsAfterFinished on the git-ssh job when jobSpec value is null
+  - it: does not apply migrationJobSpec to the git-ssh job
     set:
       iq_server:
         tag: "1.148.0"
         useGitSsh: true
       iq_server_jobs:
-        jobSpec:
+        migrationJobSpec:
+          ttlSecondsAfterFinished: null
+    asserts:
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 0
+        documentIndex: 1
+  - it: omits ttlSecondsAfterFinished on the git-ssh job when gitSshJobSpec value is null
+    set:
+      iq_server:
+        tag: "1.148.0"
+        useGitSsh: true
+      iq_server_jobs:
+        gitSshJobSpec:
           ttlSecondsAfterFinished: null
     asserts:
       - isNull:
           path: spec.ttlSecondsAfterFinished
         documentIndex: 1
-  - it: renders extra jobSpec fields onto the git-ssh job
+  - it: renders extra gitSshJobSpec fields onto the git-ssh job
     set:
       iq_server:
         tag: "1.148.0"
         useGitSsh: true
       iq_server_jobs:
-        jobSpec:
+        gitSshJobSpec:
           ttlSecondsAfterFinished: 120
           backoffLimit: 3
     asserts:
@@ -592,6 +605,18 @@ tests:
           path: spec.backoffLimit
           value: 3
         documentIndex: 1
+  - it: does not apply gitSshJobSpec to the migrate-db job
+    set:
+      iq_server:
+        tag: "1.148.0"
+      iq_server_jobs:
+        gitSshJobSpec:
+          ttlSecondsAfterFinished: null
+    asserts:
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 0
+        documentIndex: 0
   - it: renders gitSshJobAnnotations onto the git-ssh job
     set:
       iq_server:

--- a/chart/tests/iq-server-jobs_test.yaml
+++ b/chart/tests/iq-server-jobs_test.yaml
@@ -513,3 +513,31 @@ tests:
                         values:
                           - iq-pool
         documentIndex: 0
+  - it: omits ttlSecondsAfterFinished when jobSpec value is null
+    set:
+      iq_server:
+        tag: "1.148.0"
+      iq_server_jobs:
+        jobSpec:
+          ttlSecondsAfterFinished: null
+    asserts:
+      - isNull:
+          path: spec.ttlSecondsAfterFinished
+        documentIndex: 0
+  - it: renders extra jobSpec fields onto the migrate-db job
+    set:
+      iq_server:
+        tag: "1.148.0"
+      iq_server_jobs:
+        jobSpec:
+          ttlSecondsAfterFinished: 120
+          backoffLimit: 3
+    asserts:
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 120
+        documentIndex: 0
+      - equal:
+          path: spec.backoffLimit
+          value: 3
+        documentIndex: 0

--- a/chart/tests/iq-server-jobs_test.yaml
+++ b/chart/tests/iq-server-jobs_test.yaml
@@ -541,3 +541,24 @@ tests:
           path: spec.backoffLimit
           value: 3
         documentIndex: 0
+  - it: renders structured jobSpec fields onto the migrate-db job
+    set:
+      iq_server:
+        tag: "1.148.0"
+      iq_server_jobs:
+        jobSpec:
+          podFailurePolicy:
+            rules:
+              - action: FailJob
+                onExitCodes:
+                  operator: In
+                  values: [1]
+    asserts:
+      - equal:
+          path: spec.podFailurePolicy.rules[0].action
+          value: FailJob
+        documentIndex: 0
+      - equal:
+          path: spec.podFailurePolicy.rules[0].onExitCodes.values[0]
+          value: 1
+        documentIndex: 0

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -293,9 +293,11 @@ iq_server:
 
 iq_server_jobs:
   migrationJobAnnotations:
-    # DB migration job annotations. ArgoCD e.g.: argocd.argoproj.io/sync-options: Replace=true
-  # Migration job spec fields; null omits a key.
-  # GitOps: ttlSecondsAfterFinished: null keeps the job (else it may loop).
+    # Annotations for the DB migration job.
+    # Example (ArgoCD): argocd.argoproj.io/sync-options: Replace=true
+  # Extra fields merged into the migration job spec; set a key to null to omit it.
+  # For GitOps, set ttlSecondsAfterFinished to null so the completed job is kept;
+  # otherwise it self-deletes and the controller may re-create it, looping.
   jobSpec:
     ttlSecondsAfterFinished: 0
   # We usually recommend not to specify default resources and to leave this as a conscious choice for the user.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -298,6 +298,10 @@ iq_server_jobs:
   migrationJobAnnotations:
     # Annotations for the DB migration job.
     # Example (ArgoCD): argocd.argoproj.io/sync-options: Replace=true
+  gitSshJobAnnotations:
+    # Annotations for the git-ssh job (only rendered when iq_server.useGitSsh is true).
+    # The git-ssh command is idempotent, so re-running it on upgrade is safe.
+    # Example (ArgoCD): argocd.argoproj.io/sync-options: Replace=true
   # Extra fields merged into the migrate-db and git-ssh job specs; set a key to null to omit it.
   # Example: ttlSecondsAfterFinished: null
   jobSpec:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -292,12 +292,14 @@ iq_server:
   affinity: {}
 
 iq_server_jobs:
+  # For GitOps, run the migrate-db job once per upgrade: keep the completed job so it
+  # isn't recreated in a loop (ttlSecondsAfterFinished: null), and let your tool
+  # replace it on upgrade since Jobs are immutable.
   migrationJobAnnotations:
     # Annotations for the DB migration job.
-    # Example (ArgoCD): argocd.argoproj.io/sync-options: Replace=true (recreate the immutable Job to re-run on upgrade)
+    # Example (ArgoCD): argocd.argoproj.io/sync-options: Replace=true
   # Extra fields merged into the migration job spec; set a key to null to omit it.
-  # For GitOps, set ttlSecondsAfterFinished to null so the completed job is kept;
-  # otherwise it self-deletes and the controller may re-create it, looping.
+  # Example: ttlSecondsAfterFinished: null
   jobSpec:
     ttlSecondsAfterFinished: 0
   # We usually recommend not to specify default resources and to leave this as a conscious choice for the user.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -294,6 +294,17 @@ iq_server:
 iq_server_jobs:
   migrationJobAnnotations:
     # Annotations to apply to the DB migration job
+  # Top-level fields spliced into the DB migration Job spec. Set a key to null to
+  # omit it from the rendered spec.
+  # For ArgoCD/GitOps, the migrate-db job otherwise loops: ttlSecondsAfterFinished
+  # deletes the completed job, ArgoCD sees it missing and re-creates it. Keep the
+  # completed job (so it stays in sync) and allow it to be replaced on upgrade:
+  #   jobSpec:
+  #     ttlSecondsAfterFinished: null
+  #   migrationJobAnnotations:
+  #     argocd.argoproj.io/sync-options: Replace=true
+  jobSpec:
+    ttlSecondsAfterFinished: 0
   # We usually recommend not to specify default resources and to leave this as a conscious choice for the user.
   # This also increases the chance that the chart runs on environments with little resources.
   # The commented values below are the minimum recommended resources for production.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -298,13 +298,17 @@ iq_server_jobs:
   migrationJobAnnotations:
     # Annotations for the DB migration job.
     # Example (ArgoCD): argocd.argoproj.io/sync-options: Replace=true
+  # Top-level fields merged into the migrate-db job spec; set a key to null to omit it.
+  # Example: ttlSecondsAfterFinished: null
+  migrationJobSpec:
+    ttlSecondsAfterFinished: 0
   gitSshJobAnnotations:
     # Annotations for the git-ssh job (only rendered when iq_server.useGitSsh is true).
     # The git-ssh command is idempotent, so re-running it on upgrade is safe.
     # Example (ArgoCD): argocd.argoproj.io/sync-options: Replace=true
-  # Extra fields merged into the migrate-db and git-ssh job specs; set a key to null to omit it.
+  # Top-level fields merged into the git-ssh job spec; set a key to null to omit it.
   # Example: ttlSecondsAfterFinished: null
-  jobSpec:
+  gitSshJobSpec:
     ttlSecondsAfterFinished: 0
   # We usually recommend not to specify default resources and to leave this as a conscious choice for the user.
   # This also increases the chance that the chart runs on environments with little resources.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -292,13 +292,13 @@ iq_server:
   affinity: {}
 
 iq_server_jobs:
-  # For GitOps, run the migrate-db job once per upgrade: keep the completed job so it
-  # isn't recreated in a loop (ttlSecondsAfterFinished: null), and let your tool
+  # For GitOps, run the migrate-db and git-ssh jobs once per upgrade: keep the completed
+  # job so it isn't recreated in a loop (ttlSecondsAfterFinished: null), and let your tool
   # replace it on upgrade since Jobs are immutable.
   migrationJobAnnotations:
     # Annotations for the DB migration job.
     # Example (ArgoCD): argocd.argoproj.io/sync-options: Replace=true
-  # Extra fields merged into the migration job spec; set a key to null to omit it.
+  # Extra fields merged into the migrate-db and git-ssh job specs; set a key to null to omit it.
   # Example: ttlSecondsAfterFinished: null
   jobSpec:
     ttlSecondsAfterFinished: 0

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -294,15 +294,11 @@ iq_server:
 iq_server_jobs:
   migrationJobAnnotations:
     # Annotations to apply to the DB migration job
-  # Top-level fields spliced into the DB migration Job spec. Set a key to null to
-  # omit it from the rendered spec.
-  # For ArgoCD/GitOps, the migrate-db job otherwise loops: ttlSecondsAfterFinished
-  # deletes the completed job, ArgoCD sees it missing and re-creates it. Keep the
-  # completed job (so it stays in sync) and allow it to be replaced on upgrade:
-  #   jobSpec:
-  #     ttlSecondsAfterFinished: null
-  #   migrationJobAnnotations:
-  #     argocd.argoproj.io/sync-options: Replace=true
+  # Top-level fields spliced into the DB migration Job spec; set a key to null to
+  # omit it. Under GitOps, consider setting ttlSecondsAfterFinished to null so the
+  # completed job is kept: with a ttl set the job is removed after it finishes, and
+  # a reconciling controller may then re-create it, looping.
+  # Jobs are immutable, so re-running on upgrade may need your GitOps tool's replace option.
   jobSpec:
     ttlSecondsAfterFinished: 0
   # We usually recommend not to specify default resources and to leave this as a conscious choice for the user.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -294,7 +294,7 @@ iq_server:
 iq_server_jobs:
   migrationJobAnnotations:
     # Annotations for the DB migration job.
-    # Example (ArgoCD): argocd.argoproj.io/sync-options: Replace=true
+    # Example (ArgoCD): argocd.argoproj.io/sync-options: Replace=true (recreate the immutable Job to re-run on upgrade)
   # Extra fields merged into the migration job spec; set a key to null to omit it.
   # For GitOps, set ttlSecondsAfterFinished to null so the completed job is kept;
   # otherwise it self-deletes and the controller may re-create it, looping.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -293,17 +293,9 @@ iq_server:
 
 iq_server_jobs:
   migrationJobAnnotations:
-    # Annotations to apply to the DB migration job
-  # Top-level fields spliced into the DB migration Job spec; set a key to null to
-  # omit it. Under GitOps, consider setting ttlSecondsAfterFinished to null so the
-  # completed job is kept: with a ttl set the job is removed after it finishes, and
-  # a reconciling controller may then re-create it, looping.
-  # Jobs are immutable, so re-running on upgrade may need your GitOps tool's replace option.
-  # Example (ArgoCD):
-  #   migrationJobAnnotations:
-  #     argocd.argoproj.io/sync-options: Replace=true
-  #   jobSpec:
-  #     ttlSecondsAfterFinished: null
+    # DB migration job annotations. ArgoCD e.g.: argocd.argoproj.io/sync-options: Replace=true
+  # Migration job spec fields; null omits a key.
+  # GitOps: ttlSecondsAfterFinished: null keeps the job (else it may loop).
   jobSpec:
     ttlSecondsAfterFinished: 0
   # We usually recommend not to specify default resources and to leave this as a conscious choice for the user.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -299,6 +299,11 @@ iq_server_jobs:
   # completed job is kept: with a ttl set the job is removed after it finishes, and
   # a reconciling controller may then re-create it, looping.
   # Jobs are immutable, so re-running on upgrade may need your GitOps tool's replace option.
+  # Example (ArgoCD):
+  #   migrationJobAnnotations:
+  #     argocd.argoproj.io/sync-options: Replace=true
+  #   jobSpec:
+  #     ttlSecondsAfterFinished: null
   jobSpec:
     ttlSecondsAfterFinished: 0
   # We usually recommend not to specify default resources and to leave this as a conscious choice for the user.


### PR DESCRIPTION
Jira: https://sonatype.atlassian.net/browse/CLM-30003

The migrate-db Job hardcoded its spec, including `ttlSecondsAfterFinished: 0`. Under GitOps the completed job self-deletes, a GitOps controller may see this re-create it, and loop.

This exposes the job's top-level spec fields via `iq_server_jobs.jobSpec` (default `{ttlSecondsAfterFinished: 0}` = unchanged behavior); setting a key to `null` omits it. GitOps users can then set `ttlSecondsAfterFinished: null` to keep the completed job and stop the loop, plus add e.g. `argocd.argoproj.io/sync-options: Replace=true` via the existing `migrationJobAnnotations` so the immutable Job is recreated (re-run) on upgrade.